### PR TITLE
Fix file error when loading musk dataset

### DIFF
--- a/mil/data/datasets/musk1.py
+++ b/mil/data/datasets/musk1.py
@@ -4,5 +4,5 @@ from mil.data.datasets.loader import load_data
 
 current_file = os.path.abspath(os.path.dirname(__file__))
 def load():
-    return load_data(current_file + './csv/musk1.csv')
+    return load_data(os.path.join(current_file, './csv/musk1.csv'))
     


### PR DESCRIPTION
@rosasalberto  Ran into this error when loading the musk dataset:

```
---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
<ipython-input-5-0016b277a58b> in <module>
----> 1 (bags_train, y_train), (bags_test, y_test) = musk1.load()

~/opt/anaconda3/lib/python3.8/site-packages/mil/data/datasets/musk1.py in load()
      5 current_file = os.path.abspath(os.path.dirname(__file__))
      6 def load():
----> 7     return load_data(current_file + './csv/musk1.csv')
      8 

~/opt/anaconda3/lib/python3.8/site-packages/mil/data/datasets/loader.py in load_data(filepath)
      8 
      9 def load_data(filepath):
---> 10     df = pd.read_csv(filepath, header=None)
     11 
     12     bags_id = df[1].unique()

~/opt/anaconda3/lib/python3.8/site-packages/pandas/io/parsers.py in parser_f(filepath_or_buffer, sep, delimiter, header, names, index_col, usecols, squeeze, prefix, mangle_dupe_cols, dtype, engine, converters, true_values, false_values, skipinitialspace, skiprows, skipfooter, nrows, na_values, keep_default_na, na_filter, verbose, skip_blank_lines, parse_dates, infer_datetime_format, keep_date_col, date_parser, dayfirst, cache_dates, iterator, chunksize, compression, thousands, decimal, lineterminator, quotechar, quoting, doublequote, escapechar, comment, encoding, dialect, error_bad_lines, warn_bad_lines, delim_whitespace, low_memory, memory_map, float_precision)
    683         )
    684 
--> 685         return _read(filepath_or_buffer, kwds)
    686 
    687     parser_f.__name__ = name

~/opt/anaconda3/lib/python3.8/site-packages/pandas/io/parsers.py in _read(filepath_or_buffer, kwds)
    455 
    456     # Create the parser.
--> 457     parser = TextFileReader(fp_or_buf, **kwds)
    458 
    459     if chunksize or iterator:

~/opt/anaconda3/lib/python3.8/site-packages/pandas/io/parsers.py in __init__(self, f, engine, **kwds)
    893             self.options["has_index_names"] = kwds["has_index_names"]
    894 
--> 895         self._make_engine(self.engine)
    896 
    897     def close(self):

~/opt/anaconda3/lib/python3.8/site-packages/pandas/io/parsers.py in _make_engine(self, engine)
   1133     def _make_engine(self, engine="c"):
   1134         if engine == "c":
-> 1135             self._engine = CParserWrapper(self.f, **self.options)
   1136         else:
   1137             if engine == "python":

~/opt/anaconda3/lib/python3.8/site-packages/pandas/io/parsers.py in __init__(self, src, **kwds)
   1915         kwds["usecols"] = self.usecols
   1916 
-> 1917         self._reader = parsers.TextReader(src, **kwds)
   1918         self.unnamed_cols = self._reader.unnamed_cols
   1919 

pandas/_libs/parsers.pyx in pandas._libs.parsers.TextReader.__cinit__()

pandas/_libs/parsers.pyx in pandas._libs.parsers.TextReader._setup_parser_source()

FileNotFoundError: [Errno 2] File b'/path/to/python3.8/site-packages/mil/data/datasets./csv/musk1.csv' does not exist: b'/path/to/python3.8/site-packages/mil/data/datasets./csv/musk1.csv'
```

Removing the `.` worked.